### PR TITLE
Use globalStorage database for source of recent workspaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "vscode_runner",
+            "request": "launch",
+            "type": "dart",
+            "program": "bin/vscode_runner.dart"
+        }
+    ]
+}

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-/// Represents the `storage.json` file that VSCode uses for configurations.
+/// Represents the `state.vscdb` file that VSCode uses for configurations.
 class Storage {
   /// A list of all the recently opened paths VSCode remembers.
   final List<String> recentPaths;
@@ -9,10 +9,10 @@ class Storage {
     required this.recentPaths,
   });
 
-  /// Generate the [recentPaths] from the `storage.json` data.
+  /// Generate the [recentPaths] from the `state.vscdb` database.
   static Storage fromJson(String data) {
     final dataMap = json.decode(data) as Map<String, dynamic>;
-    final rawPathList = dataMap['openedPathsList']['entries'] as List;
+    final rawPathList = dataMap['entries'] as List;
     final pathMaps = rawPathList.cast<Map<String, dynamic>>();
     final paths =
         pathMaps.map((e) => e['folderUri'] ?? '').toList().cast<String>();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "30.0.0"
+    version: "34.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "3.2.0"
   args:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   crypto:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.6"
+    version: "0.6.8"
   ffi:
     dependency: transitive
     description:
@@ -140,14 +140,14 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   krunner:
     dependency: "direct main"
     description:
       name: krunner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   lints:
     dependency: "direct dev"
     description:
@@ -203,7 +203,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   petitparser:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   pool:
     dependency: transitive
     description:
@@ -287,7 +287,14 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
+  sqlite3:
+    dependency: "direct main"
+    description:
+      name: sqlite3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   stack_trace:
     dependency: transitive
     description:
@@ -322,21 +329,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.3"
+    version: "1.20.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.7"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
@@ -350,7 +357,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.4.0"
+    version: "8.1.0"
   watcher:
     dependency: transitive
     description:
@@ -378,7 +385,7 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.0+1"
   xml:
     dependency: transitive
     description:
@@ -394,4 +401,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   krunner: ^0.1.0
+  sqlite3: ^1.5.1
   xdg_directories: ^0.2.0
 
 dev_dependencies:


### PR DESCRIPTION
VSCode recently moved the storage for the recent workspaces,
it is now in the globalStorage `state.vscdb` file.

https://github.com/microsoft/vscode/issues/138072

This update sources this database to fix compatability with
the new version of VSCode (1.64).