### PR TITLE
fix: Handle empty recent workspaces in VS Code database

### DIFF
--- a/lib/database.dart
+++ b/lib/database.dart
@@ -109,6 +109,11 @@ class VSCodeDatabase {
     );
     db.dispose();
 
+    if (rows.isEmpty) {
+      log.i('No recent workspaces found in VSCode database.');
+      return [];
+    }
+
     final jsonString = rows.first.values.first as String;
     final recentPaths = _recentPathsFromJson(jsonString);
 


### PR DESCRIPTION
Fixes a crash that occurs when the VS Code database contains no recent workspaces.